### PR TITLE
fix: wrap map methods on parsed cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mauss changelog
 
+## Unreleased
+
+- fix TypeError on cookies parse object
+
 ## 0.1.2
 
 - [#22](https://github.com/devmauss/mauss/pull/22): fix handling empty and undefined cookies

--- a/src/web/cookies.ts
+++ b/src/web/cookies.ts
@@ -33,11 +33,11 @@ export function parse(source: string | undefined = '') {
 			}
 			return '';
 		},
-		has: jar.has,
-		get: jar.get,
-		keys: jar.keys,
-		values: jar.values,
-		entries: jar.entries,
+		has: (key: string) => jar.has(key),
+		get: (key: string) => jar.get(key),
+		keys: () => jar.keys(),
+		values: () => jar.values(),
+		entries: () => jar.entries(),
 	};
 }
 


### PR DESCRIPTION
This will prevent `TypeError` on parsed cookies map