### PR TITLE
chore: update svelte prettier options

### DIFF
--- a/prettier.json
+++ b/prettier.json
@@ -22,7 +22,7 @@
 		{
 			"files": ["*.svelte"],
 			"options": {
-				"svelteSortOrder": "scripts-markup-styles-options",
+				"svelteSortOrder": "options-scripts-markup-styles",
 				"svelteStrictMode": false,
 				"svelteBracketNewLine": true,
 				"svelteAllowShorthand": true,

--- a/prettier.json
+++ b/prettier.json
@@ -24,7 +24,7 @@
 			"options": {
 				"svelteSortOrder": "scripts-markup-styles-options",
 				"svelteStrictMode": false,
-				"svelteBracketNewLine": false,
+				"svelteBracketNewLine": true,
 				"svelteAllowShorthand": true,
 				"svelteIndentScriptAndStyle": true
 			}


### PR DESCRIPTION
Turns out it will only move the bracket to new line when it's a multiline element and will preserve when it's only one line. So this should make it clearer when working with multiple nested multiline elements.

Also, moving options to the start of the order makes sense so it'll be noticed and seen as the first thing. Placing it at the end will move it out of the way and make the svelte file cleaner as it'll probably only be configured once, but it's not really discoverable and will lead to confusion.